### PR TITLE
11 new matches

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -5,9 +5,11 @@
 
 typedef u16 AnimalID;
 #define AnimalID_MUK        89
+#define AnimalID_SHELLDER   90
 #define AnimalID_STARYU     120
 #define AnimalID_STARMIE    121
 #define AnimalID_MAGIKARP   129
 #define AnimalID_MEW        151
+#define AnimalID_MAX        151
 
 #endif

--- a/include/constants.h
+++ b/include/constants.h
@@ -10,6 +10,6 @@ typedef u16 AnimalID;
 #define AnimalID_STARMIE    121
 #define AnimalID_MAGIKARP   129
 #define AnimalID_MEW        151
-#define AnimalID_MAX        151
+#define POKEDEX_MAX        151
 
 #endif

--- a/include/functions.h
+++ b/include/functions.h
@@ -37,12 +37,14 @@ void spawnAnimalUsingDeltaHeight(s32 gObjID, u16 id, RoomGFX* roomA, RoomGFX* ro
 
 void ren_func_800192DC(GObj* obj);
 
-char* func_8009B9D0(s16);
-s32 func_8009BB4C(s32);
+char* getPokemonName(s32);
+s32 func_8009BB4C(s32 pkmnID);
 s32 func_8009BC68(void);
 void func_8009FBC4(void);
+void func_8009FB50(u8 arg0, u8 arg1, u8 arg2);
 void func_800A19D8(void);
 void func_800A1A50(Gfx**);
+void* func_800A73C0(u32 romSrcStart, u32 romSrcEnd);
 void func_800A7470(s32, s32, s32);
 void func_800A7860(s32, f32);
 void func_800A7F68(s32, s32);
@@ -111,9 +113,12 @@ s32 func_80346EF0_826660(s32);
 void func_80356FBC_4F73CC(void);
 void func_803586C0_4F8AD0(void);
 void func_80359074_4F9484(void);
+void func_8035FEEC_5002FC(GObj*, s32);
 
 void func_8036406C_50447C(s32*, ObjectSpawn*, AnimalDef*);
 void func_803641B8_5045C8(s32, AnimalDef*);
+s32 func_80364718(GObj *);
+s32 func_80364718_504B28(GObj *obj);
 void func_8036650C_50691C(void);
 void* func_8036A194_83D944(u32);
 void func_8036A3F8_83DBA8(void*, s32);

--- a/include/sys/om.h
+++ b/include/sys/om.h
@@ -187,7 +187,7 @@ typedef struct GObjProcess {
     /* 0x00 */ struct GObjProcess* next; // Points to next process in free or object process list
     /* 0x04 */ struct GObjProcess* prev; // Points to previous process in object process list
     /* 0x08 */ struct GObjProcess* nextInPriorityList;
-    /* 0x08 */ struct GObjProcess* prevInPriorityList;
+    /* 0x0C */ struct GObjProcess* prevInPriorityList;
     /* 0x10 */ s32 priority;
     /* 0x14 */ u8 kind;
     /* 0x15 */ u8 paused;

--- a/src/47380.c
+++ b/src/47380.c
@@ -144,16 +144,16 @@ PhotoData* func_8009BC80(s32 photoIndex) {
     return &D_800B0598[photoIndex];
 }
 
-typedef struct unk_func_8009BCC4 {
+typedef struct UnkFunc8009BCC4 {
     s32 unk_00_25 : 7;
     u8 unk_00_17 : 8;
     s32 unk_00_00 : 16;
     u8 pad[0x1C];
     s32 unk_20_19 : 13;
     s32 unk_20_00 : 19;
-} unk_func_8009BCC4;
+} UnkFunc8009BCC4;
 
-s32 func_8009BCC4(unk_func_8009BCC4* arg0) {
+s32 func_8009BCC4(UnkFunc8009BCC4* arg0) {
     s32 temp_v0;
     s32 ret;
 
@@ -161,24 +161,24 @@ s32 func_8009BCC4(unk_func_8009BCC4* arg0) {
         return -1;
     }
     switch (arg0->unk_00_17 & 0xE0) {
-    default:
-        ret = -1;
-        break;
-    case 0x60:
-        ret = 0x3EC;
-        break;
-    case 0x80:
-        ret = 0x3FA;
-        break;
-    case 0xA0:
-        ret = 0x3FE;
-        break;
-    case 0xE0:
-        ret = 0x40B;
-        break;
-    case 0x20:
-        ret = arg0->unk_20_19;
-        break;
+        default:
+            ret = -1;
+            break;
+        case 0x60:
+            ret = 0x3EC;
+            break;
+        case 0x80:
+            ret = 0x3FA;
+            break;
+        case 0xA0:
+            ret = 0x3FE;
+            break;
+        case 0xE0:
+            ret = 0x40B;
+            break;
+        case 0x20:
+            ret = arg0->unk_20_19;
+            break;
     }
     return ret;
 }

--- a/src/47380.c
+++ b/src/47380.c
@@ -32,7 +32,6 @@ extern char D_800AFE84[16]; // = "Ｓｉｇｎ？";
 extern char D_800AFE90[13]; // = "Ｓｉｇｎ";
 extern char D_800AFE9C[4];  // = "Ｓｉｇｎ？";
 
-#ifdef RODATA_MIGRATED
 char* getPokemonName(s32 pkmnID) {
     if (pkmnID > 0 && pkmnID <= POKEDEX_MAX) {
         return (&D_800AE284)[pkmnID];
@@ -63,15 +62,11 @@ char* getPokemonName(s32 pkmnID) {
         case 0x258:
         case 0x259:
         case 0x25A:
-            return "Ｓｉｇｎ？";
+            return "？";
         default:
             return NULL;
     }
 }
-#else
-#pragma GLOBAL_ASM("asm/nonmatchings/47380/getPokemonName.s")
-#endif
-
 
 s32 func_8009BB4C(s32 pkmnID) {
     s32 ret;

--- a/src/47380.c
+++ b/src/47380.c
@@ -34,7 +34,7 @@ extern char D_800AFE9C[4];  // = "Ｓｉｇｎ？";
 
 #ifdef RODATA_MIGRATED
 char* getPokemonName(s32 pkmnID) {
-    if (pkmnID > 0 && pkmnID <= AnimalID_MAX) {
+    if (pkmnID > 0 && pkmnID <= POKEDEX_MAX) {
         return (&D_800AE284)[pkmnID];
     }
     if (pkmnID == 0x3EC || pkmnID == 0x3F2 || pkmnID == 0x3FA || pkmnID == 0x3FE || pkmnID == 0x404 ||
@@ -80,7 +80,7 @@ s32 func_8009BB4C(s32 pkmnID) {
     if (pkmnID == 0x25B) {
         pkmnID = AnimalID_SHELLDER;
     }
-    if (pkmnID > 0 && pkmnID <= AnimalID_MAX) {
+    if (pkmnID > 0 && pkmnID <= POKEDEX_MAX) {
         ret = D_800AE4E4[pkmnID - 1];
     } else {
         switch (pkmnID) {

--- a/src/47380.c
+++ b/src/47380.c
@@ -1,14 +1,114 @@
 #include "common.h"
+#include "ld_addrs.h"
 
-extern s32 D_800AC0F0;
+void func_8009D21C(s32 arg0, s32* arg1);
+
+typedef struct PhotoData {
+    u8 pad[0x3A0];
+} PhotoData; // Size: 0x3A0
+
 extern s32 D_800AE27C;
 extern s32 D_800AE280;
-extern s32 D_800B0598;
+extern PhotoData D_800B0598[60]; // Size: 0xD980 - All photos taken in a level
 extern u8 D_800BDF1E;
+extern u8 D_800BDF1C;
+extern u8 D_800BDF1D;
+extern s32 D_800BDF20[3];
 
-#pragma GLOBAL_ASM("asm/nonmatchings/47380/func_8009B9D0.s")
+// rodata
+extern s32 D_800AC0F0;
+extern char* D_800AE284; // Pokedex entries
+extern s8 D_800AE4E4[];
+// s8 D_800AE4E4[] = {
+//     0,  -1, -1, 1,  2,  3,  4,  -1, -1, -1, 5,  6,  -1, 7,  -1, 8,  -1, -1, -1, -1, -1, -1, -1, -1, 9,  -1,
+//     10, 11, -1, -1, -1, -1, -1, -1, -1, -1, 12, -1, 13, -1, 14, -1, -1, -1, 15, -1, -1, -1, -1, 16, 17, 18,
+//     -1, 19, -1, 20, -1, 21, 22, 23, -1, -1, -1, -1, -1, -1, -1, -1, -1, 24, 25, -1, -1, 26, 27, -1, -1, 28,
+//     29, 30, 31, 32, -1, 33, -1, -1, -1, 34, 35, 36, 37, -1, 38, -1, -1, -1, -1, -1, -1, -1, 39, -1, -1, -1,
+//     -1, -1, -1, -1, 40, -1, -1, -1, 41, -1, 42, -1, -1, 43, -1, 44, 45, -1, 46, 47, 48, 49, -1, -1, 50, 51,
+//     52, 53, 54, -1, -1, -1, 55, -1, -1, -1, -1, -1, 56, 57, 58, 59, 60, -1, 61, -1, 62, 0,  0,  0,  0,  0,
+// };
+extern char D_800AFE80[4];  // = "？";
+extern char D_800AFE84[16]; // = "Ｓｉｇｎ？";
+extern char D_800AFE90[13]; // = "Ｓｉｇｎ";
+extern char D_800AFE9C[4];  // = "Ｓｉｇｎ？";
 
-#pragma GLOBAL_ASM("asm/nonmatchings/47380/func_8009BB4C.s")
+#ifdef RODATA_MIGRATED
+char* getPokemonName(s32 pkmnID) {
+    if (pkmnID > 0 && pkmnID <= AnimalID_MAX) {
+        return (&D_800AE284)[pkmnID];
+    }
+    if (pkmnID == 0x3EC || pkmnID == 0x3F2 || pkmnID == 0x3FA || pkmnID == 0x3FE || pkmnID == 0x404 ||
+        pkmnID == 0x40B) {
+        if (func_800BFCA0_5CB40(5) == 0) {
+            return "？";
+        }
+    }
+    if (pkmnID == 0x3EC || pkmnID == 0x3F2 || pkmnID == 0x3FA || pkmnID == 0x3FE || pkmnID == 0x404 ||
+        pkmnID == 0x40B) {
+        if (func_800BF3D4_5C274(pkmnID) == 0) {
+            return "Ｓｉｇｎ？";
+        }
+    }
+    switch (pkmnID) {
+        case 0x25B:
+            return (&D_800AE284)[AnimalID_SHELLDER];
+        case 0x3EC:
+        case 0x3F2:
+        case 0x3FA:
+        case 0x3FE:
+        case 0x404:
+        case 0x40B:
+            return "Ｓｉｇｎ";
+        case 0x1F4:
+        case 0x258:
+        case 0x259:
+        case 0x25A:
+            return "Ｓｉｇｎ？";
+        default:
+            return NULL;
+    }
+}
+#else
+#pragma GLOBAL_ASM("asm/nonmatchings/47380/getPokemonName.s")
+#endif
+
+
+s32 func_8009BB4C(s32 pkmnID) {
+    s32 ret;
+    s32 temp = D_800AE4E4[150];
+
+    if (pkmnID == 0x25B) {
+        pkmnID = AnimalID_SHELLDER;
+    }
+    if (pkmnID > 0 && pkmnID <= AnimalID_MAX) {
+        ret = D_800AE4E4[pkmnID - 1];
+    } else {
+        switch (pkmnID) {
+            case 0x3EC:
+                ret = temp + 1;
+                break;
+            case 0x3F2:
+                ret = temp + 2;
+                break;
+            case 0x404:
+                ret = temp + 3;
+                break;
+            case 0x3FE:
+                ret = temp + 4;
+                break;
+            case 0x3FA:
+                ret = temp + 5;
+                break;
+            case 0x40B:
+                ret = temp + 6;
+                break;
+            default:
+                ret = -1;
+                break;
+        }
+    }
+    return ret;
+}
 
 s32 func_8009BBF4(void) {
     return D_800AE27C;
@@ -18,19 +118,70 @@ s32 func_8009BC00(void) {
     return D_800AE280;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/47380/func_8009BC0C.s")
+s32 func_8009BC0C(s32 arg0) {
+    s32 i;
+
+    for (i = 0; i < D_800AE280 && i < ARRAY_COUNT(D_800BDF20); i++) {
+        if (arg0 == D_800BDF20[i]) {
+            return 0;
+        }
+    }
+    return 1;
+}
 
 s32 func_8009BC68(void) {
     return gPhotoCount;
 }
 
-s32* func_8009BC74(void) {
-    return &D_800B0598;
+PhotoData* func_8009BC74(void) {
+    return D_800B0598;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/47380/func_8009BC80.s")
+PhotoData* func_8009BC80(s32 photoIndex) {
+    if (photoIndex < 0 || gPhotoCount < photoIndex) {
+        return NULL;
+    }
+    return &D_800B0598[photoIndex];
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/47380/func_8009BCC4.s")
+typedef struct unk_func_8009BCC4 {
+    s32 unk_00_25 : 7;
+    u8 unk_00_17 : 8;
+    s32 unk_00_00 : 16;
+    u8 pad[0x1C];
+    s32 unk_20_19 : 13;
+    s32 unk_20_00 : 19;
+} unk_func_8009BCC4;
+
+s32 func_8009BCC4(unk_func_8009BCC4* arg0) {
+    s32 temp_v0;
+    s32 ret;
+
+    if (arg0->unk_00_25 < 0) {
+        return -1;
+    }
+    switch (arg0->unk_00_17 & 0xE0) {
+    default:
+        ret = -1;
+        break;
+    case 0x60:
+        ret = 0x3EC;
+        break;
+    case 0x80:
+        ret = 0x3FA;
+        break;
+    case 0xA0:
+        ret = 0x3FE;
+        break;
+    case 0xE0:
+        ret = 0x40B;
+        break;
+    case 0x20:
+        ret = arg0->unk_20_19;
+        break;
+    }
+    return ret;
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/47380/func_8009BD4C.s")
 
@@ -110,7 +261,18 @@ void func_8009D1E8(u32 arg0, s32 arg1, s32 arg2) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/47380/func_8009FA68.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/47380/func_8009FB50.s")
+void func_8009FB50(u8 arg0, u8 arg1, u8 arg2) {
+    s32* temp_v0;
+
+    D_800BDF1C = arg0;
+    D_800BDF1D = arg1;
+    D_800BDF1E = arg2;
+    D_800AC0F0 = -1;
+    temp_v0 = func_800A73C0((u32) AB5980_ROM_START, (u32) AB5980_ROM_END);
+    if (temp_v0 != NULL) {
+        func_8009D21C(3, temp_v0);
+    }
+}
 
 void func_8009FBC4(void) {
     GObj* curObj;

--- a/src/5047F0.c
+++ b/src/5047F0.c
@@ -1,11 +1,71 @@
 #include "common.h"
 
-#pragma GLOBAL_ASM("asm/nonmatchings/5047F0/func_803643E0_5047F0.s")
+extern f32 D_80393AC0_533ED0;
+extern f32 D_80393AC4_533ED4;
+extern Mtx4f D_803B14D8_5518E8;
+extern Mtx4f D_803B1518_551928;
+void func_803643E0_5047F0(OMCamera* cam);
+s32 func_80364618_504A28(GObj* obj, f32 x, f32 y, f32 z);
+s32 func_80364494_5048A4(OMCamera* cam, f32* arg1, f32* arg2, f32* arg3, f32* arg4);
+extern f32 D_80393AC8_533ED8;
+
+void func_803643E0_5047F0(OMCamera* cam) {
+    hal_perspective_fast_f(D_803B1518_551928, NULL, cam->perspMtx.persp.fovy, cam->perspMtx.persp.aspect,
+                           cam->perspMtx.persp.near, cam->perspMtx.persp.far, cam->perspMtx.persp.scale);
+    hal_look_at_f(D_803B14D8_5518E8, cam->viewMtx.lookAt.eye.x, cam->viewMtx.lookAt.eye.y, cam->viewMtx.lookAt.eye.z,
+                  cam->viewMtx.lookAt.at.x, cam->viewMtx.lookAt.at.y, cam->viewMtx.lookAt.at.z,
+                  cam->viewMtx.lookAt.up.x, cam->viewMtx.lookAt.up.y, cam->viewMtx.lookAt.up.z);
+    guMtxCatF(D_803B14D8_5518E8, D_803B1518_551928, D_803B1518_551928);
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/5047F0/func_80364494_5048A4.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/5047F0/func_80364618_504A28.s")
+s32 func_80364618_504A28(GObj* obj, f32 x, f32 y, f32 z) {
+    f32 outX;
+    f32 outY;
+    f32 outZ;
+    s32 temp;
+    s32 var_v0;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/5047F0/func_80364718_504B28.s")
+    guMtxXFMF(D_803B14D8_5518E8, x, y, z, &outX, &outY, &outZ);
+    if (outZ > -1.0f) {
+        return 1;
+    }
+    if (outZ < D_80393AC0_533ED0) {
+        return 1;
+    }
+    temp = (outX * D_80393AC4_533ED4) / outZ;
+    if (temp < -240 || temp > 240) {
+        return 1;
+    }
+    temp = (outY * D_80393AC4_533ED4) / outZ;
+    if (temp < -180 || temp > 180) {
+        return 1;
+    }
+    return 0;
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/5047F0/func_803647BC_504BCC.s")
+s32 func_80364718_504B28(GObj* obj) {
+    Animal* animal = GET_ANIMAL(obj);
+    if (GET_ANIMAL(obj)->flags & 0x40) {
+        func_8035FEEC_5002FC(obj, 0);
+        return 0;
+    }
+    if (D_80393AC8_533ED8 < GET_ANIMAL(obj)->playerDist) {
+        func_8035FEEC_5002FC(obj, 1);
+        return 1;
+    }
+    if (func_80364618_504A28(obj, animal->collPosition.x, animal->collPosition.y, animal->collPosition.z) != 0) {
+        func_8035FEEC_5002FC(obj, 1);
+        return 1;
+    }
+    func_8035FEEC_5002FC(obj, 0);
+    return 0;
+}
+
+void func_803647BC_504BCC(GObj* obj) {
+    DObj* dobj;
+
+    dobj = obj->data.dobj;
+    func_80364618_504A28(obj, dobj->position.v.x, dobj->position.v.y, dobj->position.v.z);
+}

--- a/src/52D70.c
+++ b/src/52D70.c
@@ -1,3 +1,12 @@
 #include "common.h"
 
-#pragma GLOBAL_ASM("asm/nonmatchings/52D70/func_800A73C0.s")
+void* func_800A73C0(u32 romSrcStart, u32 romSrcEnd) {
+    void* ramDst;
+
+    if (romSrcEnd < romSrcStart) {
+        return NULL;
+    }
+    ramDst = gtlMalloc(romSrcEnd - romSrcStart, 8);
+    dmaReadRom((void* ) romSrcStart, ramDst, romSrcEnd - romSrcStart);
+    return ramDst;
+}

--- a/src/98C330.c
+++ b/src/98C330.c
@@ -991,7 +991,7 @@ s32 func_801DE204_98DC74(Photo* photo) {
         if (sp208) {
             func_8036C898_840048(D_802290DC_9D8B4C, "\\BOh! This is exactly the PKMN\nSign I've been looking for!");
         } else {
-            func_8037519C_84894C(D_802290DC_9D8B4C, "Let me see...\nThis is %s!!", func_8009B9D0(photo->pkmnID));
+            func_8037519C_84894C(D_802290DC_9D8B4C, "Let me see...\nThis is %s!!", getPokemonName(photo->pkmnID));
         }
     }
     if (!D_801F3E34_9A38A4 && (func_801DD05C_98CACC(D_802290DC_9D8B4C, 0) == 0x4000)) {
@@ -1041,7 +1041,7 @@ s32 func_801DE204_98DC74(Photo* photo) {
             func_8036D448_840BF8(1);
             func_8036D3E8_840B98(-1, 3);
             auPlaySound(0x4D);
-            func_8037519C_84894C(D_802290DC_9D8B4C, "%s's picture\nis in the PKMN Report already.", func_8009B9D0(photo->pkmnID));
+            func_8037519C_84894C(D_802290DC_9D8B4C, "%s's picture\nis in the PKMN Report already.", getPokemonName(photo->pkmnID));
             func_8036D4A0_840C50(0);
             if (photo->specialID != 0) {
                 auPlaySound(0x4E);
@@ -1492,7 +1492,7 @@ s32 func_801DE204_98DC74(Photo* photo) {
             func_8036B9EC_83F19C(D_802290DC_9D8B4C, 0, 0x10);
             func_8036C898_840048(D_802290DC_9D8B4C, "There are other ");
             auPlaySoundWithParams(0x60, 0x7FFF, 0x40, 0.7f, 0xA);
-            func_8037519C_84894C(D_802290DC_9D8B4C, "%s", func_8009B9D0(photo->pkmnID));
+            func_8037519C_84894C(D_802290DC_9D8B4C, "%s", getPokemonName(photo->pkmnID));
             func_8036D448_840BF8(1);
             func_8036D3E8_840B98(-1, 3);
             func_8036B9EC_83F19C(D_802290DC_9D8B4C, 0, 0x20);
@@ -1979,7 +1979,7 @@ void func_801E2454_991EC4(void) {
             }
             func_8036A8E4_83E094(D_802290E4_9D8B54);
             func_8036A8E4_83E094(D_802290DC_9D8B4C);
-            sp48 = func_8009B9D0(photo->pkmnID);
+            sp48 = getPokemonName(photo->pkmnID);
             if (sp48 != NULL) {
                 func_8036D448_840BF8(0);
                 func_8036D3E8_840B98(0, 4);

--- a/src/993F80.c
+++ b/src/993F80.c
@@ -150,7 +150,7 @@ s32 func_801E48CC_99433C(const void* arg0, const void* arg1) {
     s32 sp2C;
 
     lhs = arg0, rhs = arg1;
-    sp2C = func_801E460C_99407C(func_8009B9D0(lhs->pkmnID), func_8009B9D0(rhs->pkmnID));
+    sp2C = func_801E460C_99407C(getPokemonName(lhs->pkmnID), getPokemonName(rhs->pkmnID));
     if (sp2C != 0) {
         return sp2C;
     }

--- a/src/AA18E0.c
+++ b/src/AA18E0.c
@@ -3,7 +3,6 @@
 
 void func_8009FA68(UNK_PTR arg0, UNK_PTR arg1);
 void func_801DC9D0_AA1A10(GObj*);
-void func_8009FB50(u8 arg0, u8 arg1, u8 arg2);
 UNK_PTR func_800BF574_5C414(s32 arg0);
 
 // data

--- a/tools/symbol_addrs.txt
+++ b/tools/symbol_addrs.txt
@@ -320,6 +320,7 @@ start_scene_manager = 0x8009B49C;
 getLevelId = 0x8009B980;
 setLevelId = 0x8009B98C;
 getLevelName = 0x8009B998;
+getPokemonName = 0x8009B9D0;
 func_800AAED0 = 0x800AAED0;
 func_800AAEE8 = 0x800AAEE8;
 func_800AAF10 = 0x800AAF10;


### PR DESCRIPTION
Function getPokemonName no longer matches since the last splat.yml changes as it messed with the rodata migration. It's ifdef'd out for now, but it does match. Also, I'm not sure why `AnimalID_SHELLDER` seems so important, but it seems to be.