### PR TITLE
Add clang-format guards

### DIFF
--- a/src/7ABB10.c
+++ b/src/7ABB10.c
@@ -20,7 +20,9 @@ void func_802D2604(GObj* obj) {
 
     omCreateProcess(obj, spawnStaryuAtGeo, 1, 1);
 
+    // clang-format off
     animal->counter = 1; animal->processFlags &= ~4;
+    // clang-format on
     animal->transitionGraph = NULL;
     runInteractionsAndWaitForFlags(obj, 4);
     runAnimalCleanup(obj);
@@ -32,7 +34,9 @@ void func_802D2684(GObj* obj) {
     Animal* animal = GET_ANIMAL(obj);
 
     omCreateProcess(obj, spawnStarmieAtGeo, 1, 1);
+    // clang-format off
     animal->counter = 1; animal->processFlags &= ~4;
+    // clang-format on
     animal->transitionGraph = NULL;
     runInteractionsAndWaitForFlags(obj, 4);
     runAnimalCleanup(obj);

--- a/src/A0BE70.c
+++ b/src/A0BE70.c
@@ -265,17 +265,23 @@ void func_800E5468_A0C9F8(void) {
                              &D_803051F0, 0, func_800E5370_A0C900, 1);
 
     sobj = D_800E8318_A0F8A8->data.sobj;
+    // clang-format off
     sobj->sprite.x = 98; sobj->sprite.y = 68;
+    // clang-format on
     sobj->sprite.attr = SP_TEXSHUF | SP_TRANSPARENT;
     omGObjAddSprite(D_800E8318_A0F8A8, &D_803072A0);
 
     sobj = sobj->next;
+    // clang-format off
     sobj->sprite.x = 96; sobj->sprite.y = 103;
+    // clang-format on
     sobj->sprite.attr = SP_TEXSHUF | SP_TRANSPARENT;
     omGObjAddSprite(D_800E8318_A0F8A8, &D_80308A00);
 
     sobj = sobj->next;
+    // clang-format off
     sobj->sprite.x = 71; sobj->sprite.y = 112;
+    // clang-format on
     sobj->sprite.attr = SP_TEXSHUF | SP_TRANSPARENT;
 }
 

--- a/src/menu_new_game/A5CC50.c
+++ b/src/menu_new_game/A5CC50.c
@@ -146,7 +146,9 @@ void func_800E1950_A5CD00(void) {
 
     D_801180B8 = ohCreateSprite(14, ohUpdateDefault, 0, 0x80000000, renDrawSprite, 1, 0x80000000, -1, &D_80117F98_A93348, 0, 0, 1);
     sobj = D_801180B8->data.sobj;
+    // clang-format off
     sobj->sprite.x = 96; sobj->sprite.y = 21;
+    // clang-format on
     sobj->sprite.attr = SP_TEXSHUF | SP_TRANSPARENT;
 }
 
@@ -261,11 +263,10 @@ void func_800E1E94_A5D244(void) {
 void func_800E1EE4_A5D294(void) {
     u8 var_a1;
 
-    var_a1 = 255; do {
+    for (var_a1 = 255; var_a1 > 128; var_a1 -= 5) {
         func_800E18A0_A5CC50(D_801180B4->data.sobj, var_a1);
         ohWait(1);
-        var_a1 -= 5;
-    } while (var_a1 > 128);
+    }
     func_800E18A0_A5CC50(D_801180B4->data.sobj, 128);
     ohWait(1);
 }

--- a/src/sys/main.c
+++ b/src/sys/main.c
@@ -109,15 +109,21 @@ void thread5_main(UNUSED void *arg) {
     osCreateMesgQueue(&gThreadingQueue, sBlockMsg, ARRAY_COUNT(sBlockMsg));
 
     osCreateThread(&sThread3, 3, &scMain, NULL, sThread3Stack + THREAD3_STACK_SIZE, THREAD3_PRI);
+    // clang-format off
     sThread3Stack[7] = STACK_PROBE_MAGIC; osStartThread(&sThread3);
+    // clang-format on
     osRecvMesg(&gThreadingQueue, NULL, OS_MESG_BLOCK);
 
     osCreateThread(&sThread4, 4, auThreadMain, NULL, sThread4Stack + THREAD4_STACK_SIZE, THREAD4_PRI);
+    // clang-format off
     sThread4Stack[7] = STACK_PROBE_MAGIC; osStartThread(&sThread4);
+    // clang-format on
     osRecvMesg(&gThreadingQueue, NULL, OS_MESG_BLOCK);
 
     osCreateThread(&sThread6, 6, contMain, NULL, sThread6Stack + THREAD6_STACK_SIZE, THREAD6_PRI);
+    // clang-format off
     sThread6Stack[7] = STACK_PROBE_MAGIC; osStartThread(&sThread6);
+    // clang-format on
     osRecvMesg(&gThreadingQueue, NULL, OS_MESG_BLOCK);
 
     gtlInit();
@@ -140,5 +146,7 @@ void game_main(void) {
     __osSetWatchLo(0x04900000 & WATCHLO_ADDRMASK);
     osInitialize();
     osCreateThread(&sThread1, 1, thread1_idle, &sThreadArgBuf, sThread1Stack + THREAD1_STACK_SIZE, OS_PRIORITY_APPMAX);
+    // clang-format off
     sThread1Stack[7] = STACK_PROBE_MAGIC; osStartThread(&sThread1);
+    // clang-format on
 }

--- a/src/sys/misc.c
+++ b/src/sys/misc.c
@@ -118,8 +118,10 @@ s32 getRandSeed(void) {
 
 u16 rand(void) {
     // Required to be one line to match.
+    // clang-format off
     sRandSeed = (sRandSeed * 0x343FD) + 0x269EC3; \
     return (sRandSeed >> 16);
+    // clang-format on
 }
 
 f32 randFloat(void) {


### PR DESCRIPTION
Should've wrapped all cases where code generation is affected by formatting