### PR TITLE
RSP cleanup and some rodata weirdness

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -344,9 +344,8 @@ def create_build_script(linker_entries: List[LinkerEntry]):
                     },
                 )
         elif isinstance(seg, splat.segtypes.common.textbin.CommonSegTextbin):
-            build(entry.object_path, entry.src_paths, "as")
-        elif isinstance(seg, splat.segtypes.common.databin.CommonSegDatabin):
-            build(entry.object_path, entry.src_paths, "as")
+            if seg.sibling is None:
+                build(entry.object_path, entry.src_paths, "as")
         elif isinstance(seg, splat.segtypes.common.bin.CommonSegBin):
             build(entry.object_path, entry.src_paths, "bin")
         else:

--- a/splat.yaml
+++ b/splat.yaml
@@ -232,10 +232,12 @@ segments:
     - [0x3E420, c, ../ultralib/src/io/vigetcurrframebuf]
     - [0x3E460, c, ../ultralib/src/io/spsetpc]
     - [0x3E4A0, hasm, ../ultralib/src/os/setwatchlo]
-    - [0x3E4B0, asm, rspboot]
-    - [0x3E580, data, rsp/aspMain]
-    - [0x3F3A0, data, gspF3DEX2H.NoN.fifo]
-    - [0x40730, data, gspL3DEX2H.fifo] # probably wrong offset
+
+    - [0x3E4B0, textbin, rsp/rspboot]
+    - [0x3E580, textbin, rsp/aspMain]
+    - [0x3F3A0, textbin, rsp/gspF3DEX2H.NoN.fifo]
+    - [0x40730, textbin, rsp/gspL3DEX2H.fifo]
+
     - [0x418C0, .data, sys/main]
     - [0x418F0, .data, sys/gtl]
     - [0x41950, .data, sys/rdp_reset]
@@ -306,9 +308,11 @@ segments:
     - [0x456D0, .rodata, ../ultralib/src/gu/cosf]
     - [0x45730, .rodata, ../ultralib/src/libc/xldtob]
     - [0x45790, .rodata, ../ultralib/src/libc/llcvt]
-    - [0x457A0, rodata, rsp/aspMain_data]
-    - [0x45A60, rodata, gspF3DEX2H.NoN.fifo]
-    - [0x45E80, rodata, gspL3DEX2H.fifo] # probably wrong offset
+
+    - { start: 0x457A0, type: databin, name: rsp/aspMain,             linker_section_order: .rodata }
+    - { start: 0x45A60, type: databin, name: rsp/gspF3DEX2H.NoN.fifo, linker_section_order: .rodata }
+    - { start: 0x45E80, type: databin, name: rsp/gspL3DEX2H.fifo,     linker_section_order: .rodata }
+
     - { start: auto, name: sys/main, type: .bss, vram: 0x80045670 }
     - { start: auto, name: sys/sched, type: .bss, vram: 0x80048730 }
     - { start: auto, name: sys/dma, type: .bss, vram: 0x800488A0 }

--- a/splat.yaml
+++ b/splat.yaml
@@ -982,8 +982,8 @@ segments:
     - [0x848B50, c]
 
     - [0x848BC0, bin] # , data]
+    - [0x879E80, data, 848B50]
 
-    - [0x879E80, .rodata, 848B50]
     - [0x879F20, .rodata, 840A50]
     - [0x879FF0, .rodata, 843790]
     - [0x87A000, .rodata, 843D10]

--- a/splat.yaml
+++ b/splat.yaml
@@ -596,22 +596,19 @@ segments:
     - [0x506FB0, data] # has sprite data which should be in 4FCFC0.c
     - [0x528530, .data, icons]
     - [0x528720, data]
-    - { start: 0x52A470, type: .rodata, name: 4F0610, linker_section_order: .data}
+    - { start: 0x52A470, type: .rodata, name: 4F0610, linker_section_order: .data }
     - [0x52A700, data]
-    - { start: 0x52A7B0, type: .rodata, name: icons, linker_section_order: .data}
+    - { start: 0x52A7B0, type: .rodata, name: icons, linker_section_order: .data }
     - [0x52A7D0, data]
     - [0x52A880, .data, 503C10]
     - [0x52A8A0, data]
     - [0x533C10, .rodata, 4FEB90]
     - [0x533E90, .rodata, 503C10]
-    - [0x533ED0, rodata]
-    - [0x533EE0, rodata]
-    - [0x533FE0, rodata]
-    - [0x534000, rodata]
-    - [0x536010, rodata]
-    - [0x53E1E0, rodata]
-    - [0x53E1F0, rodata]
-    - [0x54AE40, rodata]
+    - [0x533ED0, .rodata, 5047F0]
+    - [0x533EE0, .rodata, 504C00]
+    - { start: 0x533FE0, type: data, linker_section_order: .rodata } # maybe it is rodata?
+    - [0x536010, .rodata, 5064F0]
+    - { start: 0x536030, type: data, linker_section_order: .rodata }
     - { name: bss_803AB1C0, type: bss, vram: 0x803AB1C0 }
     #- { name: 503C10, type: bss, vram: 0x803B0F60 }
     #- { start: auto, name: bss_803B12C0, type: bss, vram: 0x803B12C0 }
@@ -1187,6 +1184,7 @@ segments:
     - [0xA9D6B0, data] # sprite
     - [0xA9F760, .data, A94940]
     - [0xA9FFE0, .rodata, A937C0]
+    - [0xAA0000, .rodata, A937C0]
     - [auto, .rodata, A94480]
     - [0xAA0010, .rodata, A94940]
     - { start: auto, name: bss_801E9A90, type: bss, vram: 0x801E9A90 }

--- a/src/app_level/5047F0.c
+++ b/src/app_level/5047F0.c
@@ -1,13 +1,10 @@
 #include "common.h"
 
-extern f32 D_80393AC0_533ED0;
-extern f32 D_80393AC4_533ED4;
 extern Mtx4f D_803B14D8_5518E8;
 extern Mtx4f D_803B1518_551928;
 void func_803643E0_5047F0(OMCamera* cam);
 s32 func_80364618_504A28(GObj* obj, f32 x, f32 y, f32 z);
 s32 func_80364494_5048A4(OMCamera* cam, f32* arg1, f32* arg2, f32* arg3, f32* arg4);
-extern f32 D_80393AC8_533ED8;
 
 void func_803643E0_5047F0(OMCamera* cam) {
     hal_perspective_fast_f(D_803B1518_551928, NULL, cam->perspMtx.persp.fovy, cam->perspMtx.persp.aspect,
@@ -31,14 +28,14 @@ s32 func_80364618_504A28(GObj* obj, f32 x, f32 y, f32 z) {
     if (outZ > -1.0f) {
         return 1;
     }
-    if (outZ < D_80393AC0_533ED0) {
+    if (outZ < -10000.0f) {
         return 1;
     }
-    temp = (outX * D_80393AC4_533ED4) / outZ;
+    temp = (outX * 228.506134f) / outZ;
     if (temp < -240 || temp > 240) {
         return 1;
     }
-    temp = (outY * D_80393AC4_533ED4) / outZ;
+    temp = (outY * 228.506134f) / outZ;
     if (temp < -180 || temp > 180) {
         return 1;
     }
@@ -51,7 +48,7 @@ s32 func_80364718_504B28(GObj* obj) {
         func_8035FEEC_5002FC(obj, 0);
         return 0;
     }
-    if (D_80393AC8_533ED8 < GET_POKEMON(obj)->playerDist) {
+    if (10000.0f < GET_POKEMON(obj)->playerDist) {
         func_8035FEEC_5002FC(obj, 1);
         return 1;
     }

--- a/src/credits/A937C0.c
+++ b/src/credits/A937C0.c
@@ -261,10 +261,6 @@ void func_credits_801DD428(void) {
     }
 }
 
-// #if 1
-// #pragma GLOBAL_ASM("asm/nonmatchings/credits/A937C0/func_credits_801DD49C.s")
-// #else
-// TODO: there should be a file split after this and before the next rodata
 void func_credits_801DD49C(GObj* arg0) {
     SObj* temp_s0;
     f32 var_f20;
@@ -283,7 +279,6 @@ void func_credits_801DD49C(GObj* arg0) {
         ohWait(1);
     }
 }
-// #endif
 
 void func_credits_801DD540(GObj* arg0) {
     u8 i;

--- a/tools/symbol_addrs.txt
+++ b/tools/symbol_addrs.txt
@@ -673,12 +673,13 @@ auSetCurrentSoundsGlobalVolume = 0x80023600;
 auSetSoundGlobalReverb = 0x80023880;
 D_80096968 = 0x80096968; // size:8
 
-gspF3DEX2_NoN_fifoTextStart = 0x8003E7A0;
-gspF3DEX2_NoN_fifoDataStart = 0x80044E60;
-gspL3DEX2_fifoTextStart = 0x8003FB30;
-gspL3DEX2_fifoDataStart = 0x80045280;
-aspMainTextStart = 0x8003D980;
-aspMainDataStart = 0x80044BA0;
+gspF3DEX2_NoN_fifoTextStart = 0x8003E7A0; // name_end:gspF3DEX2_NoN_fifoTextEnd
+gspF3DEX2_NoN_fifoDataStart = 0x80044E60; // name_end:gspF3DEX2_NoN_fifoDataEnd
+gspL3DEX2_fifoTextStart = 0x8003FB30; // name_end:gspL3DEX2_fifoTextEnd
+gspL3DEX2_fifoDataStart = 0x80045280; // name_end:gspL3DEX2_fifoDataEnd
+aspMainTextStart = 0x8003D980; // name_end:aspMainTextEnd
+aspMainDataStart = 0x80044BA0; // name_end:aspMainDataEnd
+rspbootTextStart = 0x8003D8B0; // name_end:rspbootTextEnd
 
 // Unreferenced strings
 D_801C5EDC_98B6FC = 0x801C5EDC; // rom:0x98B6FC type:asciz


### PR DESCRIPTION
- Change rsp files to use textbin and databin
- Change 848B50 from `rodata` to `data` to fix the rodata ordering, because the ordering didn't make sense.
![image](https://github.com/ethteck/pokemonsnap/assets/7416381/c5363c7d-68a1-408d-af6d-9dbc8c4989be)
- Fix rodata weirdness of `app_level`.
  - I'm not sure if `533FE0` is data or rodata. It has a few arrays that may be just `const` arrays