### PR TITLE
Format workflow: scope to changed files and surface failures

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          fetch-depth: 0
 
       - uses: cpp-linter/cpp-linter-action@v2
         id: linter
@@ -28,3 +29,6 @@ jobs:
           format-review: true
           extensions: c,h
           ignore: ultralib
+
+      - if: steps.linter.outputs.checks-failed > 0
+        run: exit 1


### PR DESCRIPTION
## Summary
- Add `fetch-depth: 0` to the checkout so `files-changed-only: true` can compute the diff against the base branch. Without it, cpp-linter silently falls back to scanning unrelated files, and any suggestions it finds on lines outside the PR diff are dropped by GitHub (review comments can only land on lines in a diff hunk).
- Add a trailing `exit 1` step when `checks-failed > 0` so the workflow turns red when clang-format wants changes. This is informational only — leave the Format job out of required status checks so it does not block merge.

## Test plan
- [ ] After merge, open a PR that intentionally misformats a changed `.c`/`.h` line and confirm an inline review suggestion appears on that line.
- [ ] Confirm the Format check goes red for the same PR but the merge button stays enabled (Format not in required status checks).
- [ ] Confirm the log no longer shows `cpp-linter` scanning files outside the PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)