### PR TITLE
Format CI: switch from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,7 +2,7 @@ name: Format
 
 on:
   push:
-  pull_request_target:
+  pull_request:
 
 jobs:
   format:


### PR DESCRIPTION
cpp-linter doesn't support `pull_request_target` — it silently skips all files. The format workflow doesn't need secrets, so `pull_request` works fine.