### PR TITLE
Build CI: fix stale merge_commit_sha in pull_request_target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Merge target branch
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "PR head:     ${{ github.event.pull_request.head.sha }}"
+          echo "Checked out: $(git rev-parse HEAD)"
+          echo "Base branch: origin/${{ github.event.pull_request.base.ref }} ($(git rev-parse origin/${{ github.event.pull_request.base.ref }}))"
+          git config user.name "CI"
+          git config user.email "ci@localhost"
+          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
+          echo "After merge: $(git rev-parse HEAD)"
+          git log --oneline -5
 
       - name: Install system dependencies
         run: sudo apt-get install -y binutils-mips-linux-gnu ninja-build


### PR DESCRIPTION
With `pull_request_target`, `merge_commit_sha` is often stale — it points to the merge commit from the *previous* push, not the current one. GitHub regenerates test merge commits asynchronously after the webhook fires, so the payload delivered to the workflow has the old value.

This was causing CI to build the wrong commit. The fix checks out `head.sha` (which is always correct) and merges the target branch on top, replicating what `merge_commit_sha` is supposed to provide.

### References

- [actions/checkout#518](https://github.com/actions/checkout/issues/518) — multiple users report `merge_commit_sha` consistently checking out the previous push's merge commit
- [GitHub REST API docs](https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database) — *"Please do not depend on using Git directly or GET /repos/{owner}/{repo}/git/refs/{ref} for updates to merge Git refs, because this content becomes outdated without warning."*
- [actions/checkout#27](https://github.com/actions/checkout/issues/27) — `refs/pull/N/merge` regenerated asynchronously, causing different merge commits across jobs