### PR TITLE
Get rid of `pull_request_target` on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,6 @@ jobs:
         run: |
           apt-get install -y binutils-mips-linux-gnu ninja-build
 
-      - name: print iconv version
-        run: |
-          iconv --version
-
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ jobs:
           fetch-depth: 0
 
       - name: Install system dependencies
-        run: apt-get install -y binutils-mips-linux-gnu ninja-build
+        run: |
+          apt-get install -y binutils-mips-linux-gnu ninja-build
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,19 +2,22 @@ name: Build
 
 on:
   push:
-  pull_request_target:
+  pull_request:
 
 jobs:
   build:
+    # This is a *private* build container.
+    container: ghcr.io/ethteck/pokemonsnap-build:main
+
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          fetch-depth: 0
 
       - name: Install system dependencies
-        run: sudo apt-get install -y binutils-mips-linux-gnu ninja-build
+        run: apt-get install -y binutils-mips-linux-gnu ninja-build
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -35,10 +38,8 @@ jobs:
         if: steps.cache-pigment64.outputs.cache-hit != 'true'
         run: cargo install pigment64
 
-      - name: Download ROM
-        env:
-          ROM_GDRIVE_ID: ${{ secrets.ROM_GDRIVE_ID }}
-        run: uvx gdown "$ROM_GDRIVE_ID" -O pokemonsnap.z64
+      - name: Get the dependency
+        run: cp /orig/* .
 
       - name: Setup
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ jobs:
         run: |
           apt-get install -y binutils-mips-linux-gnu ninja-build
 
+      - name: print iconv version
+        run: |
+          iconv --version
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install Python dependencies
         run: uv sync
 
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Cache pigment64
         id: cache-pigment64
         uses: actions/cache@v5

--- a/configure.py
+++ b/configure.py
@@ -232,7 +232,7 @@ def create_build_script(linker_entries: List[LinkerEntry]):
     ninja.rule(
         "as",
         description="as $in",
-        command=f"bash -o pipefail -c '{CROSS_CPP} {COMMON_INCLUDES} $in -o - | iconv -t EUC-JP | {CROSS_AS} -G0 {COMMON_INCLUDES} -EB -mtune=vr4300 -march=vr4300 -o $out'",
+        command=f"bash -o pipefail -c '{CROSS_CPP} {COMMON_INCLUDES} $in -o - | iconv -f UTF-8 -t EUC-JP | {CROSS_AS} -G0 {COMMON_INCLUDES} -EB -mtune=vr4300 -march=vr4300 -o $out'",
     )
 
     ninja.rule(


### PR DESCRIPTION
Introduces a docker based approach to get the stuff needed to build the repo in CI, instead of using GHA secrets and `pull_request_target` to get PRs to work as intended.

`pull_request_target` is not desirable because it is a pain to work with and it opens the door for bad actors to attack a repository and steal secrets.

This approach is documented here https://github.com/encounter/dtk-template/blob/main/docs/github_actions.md . Thanks a lot for the GC/Wii community and Encounter for the idea.

The n64 adaptation of this idea was taken from here https://github.com/AngheloAlf/drmario64/pull/19